### PR TITLE
also remove '/repos' in url link path (causes a 404 response).

### DIFF
--- a/views/iteration.js
+++ b/views/iteration.js
@@ -36,7 +36,7 @@ module.exports = function (iteration) {
     h('div',
       h('ul',
         iteration.links.map(function (l) {
-          var url = l.url.replace('https://api.github.com', 'https://github.com')
+          var url = l.url.replace('https://api.github.com/repos', 'https://github.com')
           return h('li', a(url, url), l.closed ? h('bold',' (DONE)') : null)
         })
       )


### PR DESCRIPTION
fixes url link to task issues in the view output.
