### PR TITLE
update regexp for parsing out valid bitcoin address

### DIFF
--- a/api/iterations.js
+++ b/api/iterations.js
@@ -5,7 +5,7 @@ var regex   = /^iteration/i  // starts with 'Iteration'
 
 //var progressbar      = /https?:\/\/feedopensource\.com\/(?:badge|iteration\/\w+\/w+)\/(1[1-km-z]{33})\/(\d+(?:\.\d+))/
 var progressbar      =
-  /https?:\/\/feedopensource\.com\/iteration\/[0-z_]+\/[0-z_]+\/(1[1-km-z]{33}).png#(\d+(?:\.\d+))/
+  /https?:\/\/feedopensource\.com\/iteration\/[0-z_]+\/[0-z_]+\/(1|3[1-9A-HJ-NP-Za-km-z]{26,33}).png#(\d+(?:\.\d+))/
 var issueFull        = /https?:\/\/github.com\/([0-z_]+)\/([0-z_]+)\/issues\/(\d+)/
 var issueNum         = /\s#(\d+)\s/
 var issueUserNum     = /\s([0-z_]+)#(\d+)\s/


### PR DESCRIPTION
Bitcoin addresses are 27 to 34 characters long, can start with 1 or 3 (multisignature transaction). It also follows base58:

https://github.com/defunctzombie/bitcoin-address/blob/master/base58.js#L6

Would be nice if @dominictarr or @joates could test this on real iteration data. I've only tested the address matching part.
