### PR TITLE
incorrect query syntax causes api to return 404 status when not using client auth.

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -13,7 +13,7 @@ var auth = (
 )
 
 function ghApi() {
-  return resolve('https://api.github.com', join.apply(null, arguments)) + auth + '&per_page=100'
+  return resolve('https://api.github.com', join.apply(null, arguments)) + auth + (auth ? '&' : '?') + 'per_page=100'
 }
 
 function bcApi() {

--- a/api/iterations.js
+++ b/api/iterations.js
@@ -6,11 +6,11 @@ var host    = config.host || 'feedopensource.com'
 var regex   = /^iteration/i  // starts with 'Iteration'
 
 var progressbar      = new RegExp(
-  "https?:\\/\\/" + host.replace(/\./, "\\.") + "\\/iteration\\/[0-z_]+\\/[0-z_]+\\/(1[1-km-z]{33}).png#(\\d+(?:\\.\\d+))")
-var issueFull        = /https?:\/\/github.com\/([0-z_]+)\/([0-z_]+)\/issues\/(\d+)/
+  "https?:\\/\\/" + host.replace(/\./, "\\.") + "\\/iteration\\/[0-z_-]+\\/[0-z_-]+\\/(1[1-km-z]{33}).png#(\\d+(?:\\.\\d+))")
+var issueFull        = /https?:\/\/github.com\/([0-z_-]+)\/([0-z_-]+)\/issues\/(\d+)/
 var issueNum         = /\s#(\d+)\s/
-var issueUserNum     = /\s([0-z_]+)#(\d+)\s/
-var issueUserRepoNum = /\s([0-z_]+)\/([0-z_]+)#(\d+)\s/
+var issueUserNum     = /\s([0-z_-]+)#(\d+)\s/
+var issueUserRepoNum = /\s([0-z_-]+)\/([0-z_-]+)#(\d+)\s/
 
 function matchAll(r, s) {
   var matches = []

--- a/api/iterations.js
+++ b/api/iterations.js
@@ -81,10 +81,10 @@ module.exports = function (issues, collaborators, user, repo) {
       var total = 0, complete = 0
       issue.links.forEach(function (e) {
         total ++
-        if(!all[e])
+        if(!all[e.url])
           complete ++
 
-        e.closed = !all[e]
+        e.closed = !all[e.url]
       })
       issue.total = total
       issue.complete = complete

--- a/api/iterations.js
+++ b/api/iterations.js
@@ -1,11 +1,12 @@
 var resolve = require('url').resolve
 var join    = require('path').join
+var config  = require('../config')
 
+var host    = config.host || 'feedopensource.com'
 var regex   = /^iteration/i  // starts with 'Iteration'
 
-//var progressbar      = /https?:\/\/feedopensource\.com\/(?:badge|iteration\/\w+\/w+)\/(1[1-km-z]{33})\/(\d+(?:\.\d+))/
-var progressbar      =
-  /https?:\/\/feedopensource\.com\/iteration\/[0-z_]+\/[0-z_]+\/(1[1-km-z]{33}).png#(\d+(?:\.\d+))/
+var progressbar      = new RegExp(
+  "https?:\\/\\/" + host.replace(/\./, "\\.") + "\\/iteration\\/[0-z_]+\\/[0-z_]+\\/(1[1-km-z]{33}).png#(\\d+(?:\\.\\d+))")
 var issueFull        = /https?:\/\/github.com\/([0-z_]+)\/([0-z_]+)\/issues\/(\d+)/
 var issueNum         = /\s#(\d+)\s/
 var issueUserNum     = /\s([0-z_]+)#(\d+)\s/
@@ -51,7 +52,7 @@ module.exports = function (issues, collaborators, user, repo) {
     if(!m) return
     issue.wallet = m[1]
     issue.target = m[2]
-    issue.feedopensource_url = 'https://feedopensource.com/iteration/' + user + '/' + repo + '/' + m[1]
+    issue.feedopensource_url = 'https://' + host + '/iteration/' + user + '/' + repo + '/' + m[1]
     issue.badge_url = issue.feedopensource_url + '.png#' + issue.target
 
     if(!wallets[issue.wallet]) {


### PR DESCRIPTION
should _always_ use client auth but since it is possible to not use any auth, need to check for this.

``` shell
curl 'https://api.github.com/repos/dominictarr/feedopensource/collaborators&per_page=100'
{
  "message": "Not Found",
  "documentation_url": "http://developer.github.com/v3"
}
```
